### PR TITLE
Fixed MaxFileSize restriction in artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,8 @@ jobs:
       id: velociraptor
       with:
         repository: velocidex/velociraptor
-        tag: v0.74
-        fileName: "velociraptor-v0.74.5-linux-amd64-musl"
+        tag: v0.76.6
+        fileName: "velociraptor-v0.76.6-linux-amd64-musl"
         out-file-path: tests
 
     - name: Build Artifacts

--- a/README.md
+++ b/README.md
@@ -96,3 +96,26 @@ another target reference.
 
 You can view the targets used in this artifact [here]({{< ref
 "docs/rules/" >}}).
+
+## Running on the command line / Testing
+
+It is easiest to run this artifact on the command line. For newer
+binaries (Velociraptor versions >= 0.76) you can use the new "run"
+mode CLI (Assume `f:\artifacts_definition` is the directory containing
+custom artifacts):
+
+```bash
+velociraptor.exe -v -D f:\artifacts_definitions\ -r Windows.Triage.Targets \
+  --MaxFileSize 10 --Targets _Live --output test.zip
+```
+
+For older Velociraptor versions use the classing CLI
+
+```bash
+velociraptor.exe -v --definitions f:\artifacts_definitions\ \
+   artifacts collect  Windows.Triage.Targets \
+   --args MaxFileSize=10 --args Targets=["""_Live"""] \
+   --output test.zip
+```
+
+The triple quote is needed on the cmd.exe console.

--- a/templates/CommonExports.yaml
+++ b/templates/CommonExports.yaml
@@ -133,9 +133,12 @@ LET DoNotUpload <= dict(ShouldUpload=FALSE)
 
 // Determine if we should upload the file based on signature.
 LET ShouldUpload(Details) = if(
-  condition=OSPath =~ TrustedPathRegex AND
-    MaxFileSize > 0 AND Details.Stat.Size > MaxFileSize,
-  then= Details + DoNotUpload,
+  condition=OSPath =~ TrustedPathRegex OR
+    ( MaxFileSize > 0 AND Details.Stat.Size > MaxFileSize ),
+  then= log(dedup=-1,
+            message="Skipped upload of %v because it too large: %d",
+            args=[OSPath, Details.Stat.Size]) &&
+        ( Details + DoNotUpload ) ,
   else=if(
        // What to do about binaries? If they have an issuer name then
        // they are signed.
@@ -166,7 +169,15 @@ LET _GetDetails(OSPath) = MaybeBinary(
      Details=dict(filename=OSPath,
                   Stat=OSPath && stat(filename=OSPath))))
 
-// Cache the hashing for speedup.
+// Cache the hashing for speedup on newer binaries.
+LET GetDetails(OSPath) = if(condition=version(function="cache") >= 2,
+then = cache(period=100000,
+             lambda="OSPath=>_GetDetails(OSPath=OSPath)",
+             name="GetDetails", key=OSPath),
+
+// Older versions can work without a cache.
+else = _GetDetails(OSPath=OSPath))
+
 LET GetDetails(OSPath) = cache(
        period=100000,
        func= _GetDetails(OSPath=OSPath),


### PR DESCRIPTION
In 0.76 the `cache()` VQL function was upgraded and this broke this old use of it.

This PR handles both new and old versions.